### PR TITLE
issue-90 Added support for inline fragments.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,9 @@
-# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
-# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
-
 name: release
 
 on:
   push:
     branches:
       - master
-    paths:
-      - '.version'
 
 jobs:
   build:
@@ -21,16 +16,9 @@ jobs:
       - run: npm ci
       - run: npm test
 
-  publish-npm:
+  publish:
     needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12
-          registry-url: https://registry.npmjs.org/
-      - run: npm ci
-      - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+    uses: mikeal/merge-release@master
+    env:
+      NPM_AUTH_TOKEN: ${{secrets.npm_token}}
+      GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.4.0 August 5, 2021
+
+Added support for inline fragments
+
 # 2.3.0 April 1, 2021
 
 Added support for return type of array set to enum values

--- a/package-lock.json
+++ b/package-lock.json
@@ -4437,9 +4437,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "lodash.memoize": {

--- a/tests/basics/inlineFragment.graphql
+++ b/tests/basics/inlineFragment.graphql
@@ -1,0 +1,40 @@
+fragment objectFragment on SimpleObjectWithNulls {
+  str0: str0
+  int
+}
+
+fragment unionFragment on UnionType {
+  ... on SimpleObjectWithNulls {
+    str: str0
+  }
+  ... on SimpleObjectWithNonNulls {
+    str1: str1
+  }
+  ... on NestedObjectType {
+    simpleObjectWithNonNulls {
+      str: str1
+    }
+  }
+}
+
+fragment arrayFragment on AnotherSimpleObjectWithNulls {
+  str3
+}
+
+fragment topLevelFragment on TopLevelObject {
+  simpleObjectWithNulls {
+    ... objectFragment
+  }
+  arrayOfSimpleObjectsWithNulls {
+    ... arrayFragment
+  }
+  unionField {
+    ... unionFragment
+  }
+}
+
+query myQuery {
+  someComplexObject {
+    ... topLevelFragment
+  }
+}

--- a/tests/basics/inlineFragment.ts
+++ b/tests/basics/inlineFragment.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from 'fs';
+import * as path from 'path';
+import { graphqlToOpenApi } from '../../index';
+import * as assert from 'assert';
+import { stringify } from 'yaml';
+
+describe('inlineFragment', function () {
+  it('should produce a valid openapi spec', function () {
+    const schemaString = readFileSync(
+      path.join(__dirname, 'inlineFragmentSchema.graphql')
+    ).toString();
+    const inputQueryFilename = path.join(__dirname, 'inlineFragment.graphql');
+    const inputQuery = readFileSync(inputQueryFilename).toString();
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const expectedOutputYaml = readFileSync(
+      path.join(__dirname, 'inlineFragment.yaml')
+    ).toString();
+    const output = graphqlToOpenApi({
+      schemaString,
+      inputQuery,
+    });
+    const actualOutput = output.openApiSchema;
+    const actualOutputYaml = stringify(
+      JSON.parse(JSON.stringify(actualOutput)),
+      {
+        sortMapEntries: true,
+      }
+    );
+    assert.ok(!!actualOutputYaml);
+    assert.equal(actualOutputYaml, expectedOutputYaml);
+  });
+});

--- a/tests/basics/inlineFragment.yaml
+++ b/tests/basics/inlineFragment.yaml
@@ -1,0 +1,65 @@
+info:
+  license:
+    name: Not specified
+  title: Not specified
+  version: Not specified
+openapi: 3.0.3
+paths:
+  /myQuery:
+    get:
+      parameters: []
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                properties:
+                  someComplexObject:
+                    nullable: true
+                    properties:
+                      arrayOfSimpleObjectsWithNulls:
+                        items:
+                          properties:
+                            str3:
+                              nullable: true
+                              type: string
+                          type: object
+                        nullable: true
+                        type: array
+                      simpleObjectWithNulls:
+                        nullable: true
+                        properties:
+                          int:
+                            nullable: true
+                            type: integer
+                          str0:
+                            nullable: true
+                            type: string
+                        type: object
+                      unionField:
+                        anyOf:
+                          - properties:
+                              str:
+                                nullable: true
+                                type: string
+                            type: object
+                          - properties:
+                              str1:
+                                nullable: false
+                                type: string
+                            type: object
+                          - properties:
+                              simpleObjectWithNonNulls:
+                                nullable: true
+                                properties:
+                                  str:
+                                    nullable: false
+                                    type: string
+                                type: object
+                            type: object
+                        nullable: true
+                    type: object
+                type: object
+          description: response
+servers:
+  - url: /

--- a/tests/basics/inlineFragmentSchema.graphql
+++ b/tests/basics/inlineFragmentSchema.graphql
@@ -1,0 +1,35 @@
+type Query {
+  query: Query
+  someComplexObject: TopLevelObject
+}
+
+type TopLevelObject {
+  unusedString: String!
+  simpleObjectWithNulls: SimpleObjectWithNulls
+  simpleObjectWithNonNulls: SimpleObjectWithNonNulls
+  nestedObject: NestedObjectType
+  arrayOfSimpleObjectsWithNulls: [AnotherSimpleObjectWithNulls]
+  unionField: UnionType
+}
+
+type SimpleObjectWithNulls {
+  str0: String
+  int: Int
+}
+
+union UnionType = SimpleObjectWithNulls | SimpleObjectWithNonNulls | NestedObjectType
+
+type SimpleObjectWithNonNulls {
+  str1: String!
+  int: Int!
+}
+
+type NestedObjectType {
+  simpleObjectWithNonNulls: SimpleObjectWithNonNulls
+  f3: AnotherSimpleObjectWithNulls!
+}
+
+type AnotherSimpleObjectWithNulls {
+  str3: String
+  int3: Int
+}


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
  <!-- 100% test coverage is required -->
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
  <!-- If you'd like to suggest a significant change to request,
       please create an issue to discuss those changes and gather
       feedback BEFORE submitting your PR. -->
- [x] If this is a version update, have you updated the CHANGELOG.md?

## PR Description

Added support for inline fragments. This capability allows a user to use fragments in their graphql query and they are represented correctly in the output openapi result. Fixes #90 and #66 .

Also added usage of a release plugin to ease future releases.
