### PR TITLE
Field merging

### DIFF
--- a/lib/GraphQLToOpenAPIConverter.ts
+++ b/lib/GraphQLToOpenAPIConverter.ts
@@ -566,6 +566,12 @@ export class GraphQLToOpenAPIConverter {
             );
             const parentObj = currentSelection[0].openApiType;
             if (parentObj.type === 'object') {
+              if (parentObj.properties[name]?.properties) {
+                openApiType.properties = {
+                  ...parentObj.properties[name]?.properties,
+                  ...openApiType.properties,
+                };
+              }
               parentObj.properties[name] = openApiType;
             } else {
               // array

--- a/lib/GraphQLToOpenAPIConverter.ts
+++ b/lib/GraphQLToOpenAPIConverter.ts
@@ -545,9 +545,15 @@ export class GraphQLToOpenAPIConverter {
             if (openApiType.anyOf) {
               openApiType.anyOf = fragment.anyOf;
             } else if (openApiType.items) {
-              openApiType.items.properties = fragment.properties;
+              openApiType.items.properties = {
+                ...openApiType.items.properties,
+                ...fragment.properties,
+              };
             } else {
-              openApiType.properties = fragment.properties;
+              openApiType.properties = {
+                ...openApiType.properties,
+                ...fragment.properties,
+              };
             }
           },
         },

--- a/tests/basics/fieldMerging.graphql
+++ b/tests/basics/fieldMerging.graphql
@@ -14,3 +14,45 @@ query fieldMerging($id: ID!) {
     }
   }
 }
+
+fragment cityState on Address {
+  city
+  state
+}
+
+query fieldMergingWithFragmentSpread($id: ID!) {
+  person(id: $id) {
+    id
+    firstName
+    lastName
+
+    address {
+      ...cityState
+    }
+
+    address {
+      country
+    }
+  }
+}
+
+fragment addressSubfields on Person {
+  address {
+    city
+    state
+  }
+}
+
+query fieldMergingWithSubfieldFragmentSpread($id: ID!) {
+  person(id: $id) {
+    id
+    firstName
+    lastName
+
+    ...addressSubfields
+
+    address {
+      country
+    }
+  }
+}

--- a/tests/basics/fieldMerging.graphql
+++ b/tests/basics/fieldMerging.graphql
@@ -1,0 +1,16 @@
+query fieldMerging($id: ID!) {
+  person(id: $id) {
+    id
+    firstName
+    lastName
+
+    address {
+      country
+    }
+
+    address {
+      city
+      state
+    }
+  }
+}

--- a/tests/basics/fieldMerging.json
+++ b/tests/basics/fieldMerging.json
@@ -1,0 +1,81 @@
+{
+  "info": {
+    "license": {
+      "name": "Not specified"
+    },
+    "title": "Not specified",
+    "version": "Not specified"
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/fieldMerging": {
+      "get": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "person": {
+                      "nullable": false,
+                      "properties": {
+                        "address": {
+                          "nullable": false,
+                          "properties": {
+                            "country": {
+                              "nullable": false,
+                              "type": "string"
+                            },
+                            "city": {
+                              "nullable": false,
+                              "type": "string"
+                            },
+                            "state": {
+                              "nullable": false,
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "firstName": {
+                          "nullable": false,
+                          "type": "string"
+                        },
+                        "id": {
+                          "nullable": false,
+                          "type": "string"
+                        },
+                        "lastName": {
+                          "nullable": false,
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "response"
+          }
+        }
+      }
+    }
+  },
+  "servers": [
+    {
+      "url": "/"
+    }
+  ]
+}

--- a/tests/basics/fieldMerging.json
+++ b/tests/basics/fieldMerging.json
@@ -71,6 +71,134 @@
           }
         }
       }
+    },
+    "/fieldMergingWithFragmentSpread": {
+      "get": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "person": {
+                      "nullable": false,
+                      "properties": {
+                        "address": {
+                          "nullable": false,
+                          "properties": {
+                            "country": {
+                              "nullable": false,
+                              "type": "string"
+                            },
+                            "city": {
+                              "nullable": false,
+                              "type": "string"
+                            },
+                            "state": {
+                              "nullable": false,
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "firstName": {
+                          "nullable": false,
+                          "type": "string"
+                        },
+                        "id": {
+                          "nullable": false,
+                          "type": "string"
+                        },
+                        "lastName": {
+                          "nullable": false,
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "response"
+          }
+        }
+      }
+    },
+    "/fieldMergingWithSubfieldFragmentSpread": {
+      "get": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "person": {
+                      "nullable": false,
+                      "properties": {
+                        "address": {
+                          "nullable": false,
+                          "properties": {
+                            "country": {
+                              "nullable": false,
+                              "type": "string"
+                            },
+                            "city": {
+                              "nullable": false,
+                              "type": "string"
+                            },
+                            "state": {
+                              "nullable": false,
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "firstName": {
+                          "nullable": false,
+                          "type": "string"
+                        },
+                        "id": {
+                          "nullable": false,
+                          "type": "string"
+                        },
+                        "lastName": {
+                          "nullable": false,
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "response"
+          }
+        }
+      }
     }
   },
   "servers": [

--- a/tests/basics/fieldMerging.ts
+++ b/tests/basics/fieldMerging.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'fs';
+import * as path from 'path';
+import { graphqlToOpenApi } from '../../index';
+import * as assert from 'assert';
+import * as stringify from 'json-stable-stringify';
+
+describe('fieldMerging', function () {
+  it('should produce a valid openapi spec', function () {
+    const schema = readFileSync(
+      path.join(__dirname, 'fieldMergingSchema.graphql')
+    ).toString();
+    const inputQueryFilename = path.join(__dirname, 'fieldMerging.graphql');
+    const query = readFileSync(inputQueryFilename).toString();
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const expectedOutput = require('./fieldMerging.json');
+    const actualOutput = graphqlToOpenApi({
+      schema,
+      query,
+    }).openApiSchema;
+    const normalizedActualOutput = stringify(actualOutput, { space: '  ' });
+    const normalizedExpectedOutput = stringify(expectedOutput, { space: '  ' });
+    assert.ok(!!actualOutput);
+    assert.equal(normalizedActualOutput, normalizedExpectedOutput);
+  });
+});

--- a/tests/basics/fieldMergingSchema.graphql
+++ b/tests/basics/fieldMergingSchema.graphql
@@ -1,0 +1,19 @@
+type Address {
+  addr1: String!
+  addr2: String
+  city: String!
+  state: String!
+  zip: String!
+  country: String!
+}
+
+type Person {
+  id: ID!
+  firstName: String!
+  lastName: String!
+  address: Address!
+}
+
+type Query {
+  person(id: ID!): Person!
+}


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
  <!-- 100% test coverage is required -->
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: #572 
- [ ] If this is a version update, have you updated the CHANGELOG.md?

## PR Description
This merges multiple references to the same field together when that field has subfields.  It fixes both the simple case given in #572 and also the more complicated case involving fragment spreads.

I'm having some trouble reaching 100% test coverage with this.  Jest is telling me that line 577 of GraphQLToOpenAPIConverter.ts is uncovered, but from what I can tell, that line is actually being invoked in the tests I added (if it wasn't, my tests should fail).  I'd love any pointers on how to fix this!
